### PR TITLE
chore: use linode-obs sloth fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions.
 ## Install
 
 ```shell
-asdf plugin add sloth
-# or
-asdf plugin add sloth https://github.com/slok/asdf-sloth.git
+asdf plugin add sloth https://github.com/linode-obs/asdf-sloth.git
 ```
 
 ## Usage

--- a/bin/install
+++ b/bin/install
@@ -30,8 +30,7 @@ install() {
   fi
 
   local download_url
-  download_url="https://github.com/slok/sloth/releases/download/v${version}/sloth-${platform}-${arch}"
-
+  download_url="https://github.com/linode-obs/sloth/releases/download/v${version}/sloth-${platform}-${arch}"
   mkdir -p "${bin_install_path}"
 
   echo "Downloading sloth from ${download_url}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path='https://api.github.com/repos/slok/sloth/releases?per_page=100'
+releases_path='https://api.github.com/repos/linode-obs/sloth/releases?per_page=100'
 
 if [ -n "${GITHUB_API_TOKEN}" ]; then
   header="-H 'Authorization: token ${GITHUB_API_TOKEN}'"


### PR DESCRIPTION
This PR updates the download_url used to point to our fork of Sloth instead of upstream so we can get the benefits of asdf while waiting for our changes to be merged upstream to Sloth